### PR TITLE
Actually use zlib-ng for C PNG decoders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,12 +164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b81e1519b0d82120d2fd469d5bfb2919a9361c48b02d82d04befc1cdd2002452"
 
 [[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
 name = "built"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,7 +308,6 @@ dependencies = [
  "innumerable",
  "libc",
  "miniz_oxide 0.8.0",
- "mtpng",
  "png",
  "rand",
  "spng",
@@ -324,15 +317,6 @@ dependencies = [
  "zune-inflate",
  "zune-png",
  "zune-qoi",
-]
-
-[[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
 ]
 
 [[package]]
@@ -420,12 +404,11 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
  "miniz_oxide 0.8.0",
 ]
 
@@ -597,15 +580,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -665,16 +639,6 @@ checksum = "54cd30df7c7165ce74a456e4ca9732c603e8dc5e60784558c1c6dc047f876733"
 dependencies = [
  "cc",
  "glob",
-]
-
-[[package]]
-name = "libz-ng-sys"
-version = "1.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0f7295a34685977acb2e8cc8b08ee4a8dffd6cf278eeccddbe1ed55ba815d5"
-dependencies = [
- "cmake",
- "libc",
 ]
 
 [[package]]
@@ -759,19 +723,6 @@ checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
  "simd-adler32",
-]
-
-[[package]]
-name = "mtpng"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527f7f1534f123055f48e993ee2a263e179dad563ef5ed960dbb8a9a49e1382"
-dependencies = [
- "crc",
- "itertools 0.10.5",
- "libz-sys",
- "rayon",
- "typenum",
 ]
 
 [[package]]
@@ -994,7 +945,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools 0.12.1",
+ "itertools",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -1257,12 +1208,6 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,14 @@ version = "0.1.0"
 byteorder-lite = "0.1.0"
 clap = { version = "4.5.4", features = ["derive"] }
 fdeflate = "0.3.5"
-flate2 = { version = "1.0.35", features = ["zlib-rs"] }
+flate2 = { version = "1.0.35" }
 image = "0.25.1"
 indicatif = "0.17.8"
 innumerable = "0.1.0"
 libc = "0.2.159"
 miniz_oxide = "0.8.0"
-mtpng = "0.3.5"
-png = { version = "0.17.13", features = ["unstable"] }
+#mtpng = "0.3.5"
+png = { version = "0.17.13" }
 rand = "0.8.5"
 spng = { version = "0.1.0", features = ["zlib-ng"] }
 walkdir = "2.5.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,12 +166,16 @@ fn main() {
                     compression_ratio * 100.0
                 );
 
-                let (bandwidth, compression_ratio) = mtpng_encode(&corpus);
-                println!(
-                    "mtpng:         {:>6.1} MP/s  {:02.2}%",
-                    bandwidth,
-                    compression_ratio * 100.0
-                );
+                // mtpng v0.4.1 breaks other benchmarks by forcing plain old zlib,
+                // so we cannot configure other crates with zlib-ng while it's present.
+                // TODO: re-enable.
+                //
+                // let (bandwidth, compression_ratio) = mtpng_encode(&corpus);
+                // println!(
+                //     "mtpng:         {:>6.1} MP/s  {:02.2}%",
+                //     bandwidth,
+                //     compression_ratio * 100.0
+                // );
 
                 let (bandwidth, compression_ratio) = image_rs_encode(&corpus, ImageFormat::Qoi);
                 println!(
@@ -298,34 +302,37 @@ fn image_rs_encode(corpus: &[PathBuf], format: ImageFormat) -> (f64, f64) {
         image.write_to(buffer, format).unwrap();
     })
 }
+// mtpng v0.4.1 breaks other benchmarks by forcing plain old zlib,
+// so we cannot configure other crates with zlib-ng while it's present.
+// TODO: re-enable.
+//
+//fn mtpng_encode(corpus: &[PathBuf]) -> (f64, f64) {
+    // measure_encode(corpus, |buffer, image| {
+    //     let mut options = mtpng::encoder::Options::new();
+    //     options
+    //         .set_compression_level(mtpng::CompressionLevel::Fast)
+    //         .unwrap();
+    //     let mut header = mtpng::Header::new();
+    //     header
+    //         .set_size(image.width() as u32, image.height() as u32)
+    //         .unwrap();
+    //     header
+    //         .set_color(
+    //             if image.color().has_alpha() {
+    //                 mtpng::ColorType::TruecolorAlpha
+    //             } else {
+    //                 mtpng::ColorType::Truecolor
+    //             },
+    //             8,
+    //         )
+    //         .unwrap();
 
-fn mtpng_encode(corpus: &[PathBuf]) -> (f64, f64) {
-    measure_encode(corpus, |buffer, image| {
-        let mut options = mtpng::encoder::Options::new();
-        options
-            .set_compression_level(mtpng::CompressionLevel::Fast)
-            .unwrap();
-        let mut header = mtpng::Header::new();
-        header
-            .set_size(image.width() as u32, image.height() as u32)
-            .unwrap();
-        header
-            .set_color(
-                if image.color().has_alpha() {
-                    mtpng::ColorType::TruecolorAlpha
-                } else {
-                    mtpng::ColorType::Truecolor
-                },
-                8,
-            )
-            .unwrap();
-
-        let mut encoder = mtpng::encoder::Encoder::new(buffer, &options);
-        encoder.write_header(&header).unwrap();
-        encoder.write_image_rows(&image.as_bytes()).unwrap();
-        encoder.finish().unwrap();
-    })
-}
+    //     let mut encoder = mtpng::encoder::Encoder::new(buffer, &options);
+    //     encoder.write_header(&header).unwrap();
+    //     encoder.write_image_rows(&image.as_bytes()).unwrap();
+    //     encoder.finish().unwrap();
+    //})
+//}
 
 fn zune_png_encode(corpus: &[PathBuf]) -> (f64, f64) {
     measure_encode(corpus, |buffer, image| {


### PR DESCRIPTION
Temporarily disable mtpng and flate2 zlib-rs backend to get zlib-ng configured for C PNG decoders. mtpng enables default features on libz-sys crate which in turn forces slow old zlib everywhere.

In the long run we probably want to split encoding benchmarks into its own binary that doesn't even share the workspace with the decoders to avoid C libraries clashing with each other.