### PR TITLE
bump png to latest in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,9 +789,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "png"
-version = "0.17.14"
+version = "0.17.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f9d46a34a05a6a57566bc2bfae066ef07585a6e3fa30fbbdff5936380623f0"
+checksum = "b67582bd5b65bdff614270e2ea89a1cf15bef71245cc1e5f7ea126977144211d"
 dependencies = [
  "bitflags",
  "crc32fast",


### PR DESCRIPTION
This would make published benchmark results easily reproducible, and lets me link to this repo from png release announcement.